### PR TITLE
fixed goToDefinition command

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -106,39 +106,9 @@ function activate(context) {
     })
 
     vscode.commands.registerCommand('nasc.touchBar.goToDefinition', function () {
-        var editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            return; // No open text editor
-        }
-
-        var position = editor.selection.active;
-
-        vscode.commands.executeCommand('vscode.executeDefinitionProvider',
-            editor.document.uri,
-            position
-        ).then(result => {
-            if (result[0]) {
-                let found = result[0]
-                var newPositionS = position.with(found.range._start.line, found.range._start.character);
-                var newPositionE = position.with(found.range._end.line, found.range._end.character);
-                var newSelection = new vscode.Selection(newPositionS, newPositionE);
-
-                vscode.commands.executeCommand('vscode.open', found.uri).then(result => {
-                    var editor = vscode.window.activeTextEditor;
-                    editor.selection = newSelection
-                    vscode.commands.executeCommand('revealLine', {
-                        lineNumber: newSelection.start.line,
-                        at: 'center'
-                    }).then(result => {
-                    }, err => {
-                    })
-                }, err => {
-                    console.log(err)
-                })
-            }
-            return true
-        })
+        vscode.commands.executeCommand('editor.action.goToDeclaration');
     });
+    
     const prov = vscode.languages.registerDefinitionProvider(
         GO_MODE, go2Def
     )


### PR DESCRIPTION
the `goToDefinition` command started failing for me.

Upon further investigation, I'm not sure why it was doing all the work it was doing, so I replaced it with a simple call to `vscode.commands.executeCommand('editor.action.goToDeclaration');`

